### PR TITLE
chore: add `repository` info to package json to all packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,10 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/paraportxyz/sdk"
+	},
 	"type": "module",
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,6 +17,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paraportxyz/sdk"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -10,6 +10,10 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/paraportxyz/sdk"
+	},
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -5,15 +5,19 @@
   "description": "Vue components for ParaPort SDK",
   "author": "Paraport",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paraportxyz/sdk"
+  },
   "keywords": [
     "paraport",
     "polkadot",
     "sdk",
     "vue"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
### Issue 

release.yaml oidc is working, now we are getting

```
"repository.url" is "", expected to match "https://github.com/paraportxyz/sdk" from provenance
```